### PR TITLE
Parallelize partial VHF computation

### DIFF
--- a/scattering/tests/test_van_hove.py
+++ b/scattering/tests/test_van_hove.py
@@ -9,7 +9,7 @@ def test_van_hove():
     trj = md.load(
         get_fn('spce.xtc'),
         top=get_fn('spce.gro')
-    )[:100]
+    )
 
     chunk_length = 2
 
@@ -20,7 +20,7 @@ def test_van_hove():
     assert np.shape(g_r_t) == (2, 200)
 
     # Check normalization to ~1
-    assert 0.95 < np.mean(g_r_t[:, 100:]) < 1.05
+    assert 0.95 < np.mean(g_r_t[:, -10:]) < 1.05
 
     fig, ax = plt.subplots()
     for i in range(len(t)):

--- a/scattering/van_hove.py
+++ b/scattering/van_hove.py
@@ -1,3 +1,4 @@
+import multiprocessing
 import itertools as it
 
 import numpy as np
@@ -42,21 +43,35 @@ def compute_van_hove(trj, chunk_length, water=False,
     n_physical_atoms = len([a for a in trj.top.atoms if a.element.mass > 0])
     unique_elements = list(set([a.element for a in trj.top.atoms if a.element.mass > 0]))
 
-    partial_dict = dict()
-
+    data = []
     for elem1, elem2 in it.combinations_with_replacement(unique_elements[::-1], 2):
-        print('doing {0} and {1} ...'.format(elem1, elem2))
-        r, g_r_t_partial = compute_partial_van_hove(trj=trj,
-                                                    chunk_length=chunk_length,
-                                                    selection1='element {}'.format(elem1.symbol),
-                                                    selection2='element {}'.format(elem2.symbol),
-                                                    r_range=r_range,
-                                                    bin_width=bin_width,
-                                                    n_bins=n_bins,
-                                                    self_correlation=self_correlation,
-                                                    periodic=periodic,
-                                                    opt=opt)
-        partial_dict[(elem1, elem2)] = g_r_t_partial
+        data.append([
+            trj,
+            chunk_length,
+            'element {}'.format(elem1.symbol),
+            'element {}'.format(elem2.symbol),
+            r_range,
+            bin_width,
+            n_bins,
+            self_correlation,
+            periodic,
+            opt,
+        ])
+
+    manager = multiprocessing.Manager()
+    partial_dict = manager.dict()
+    jobs = []
+    for d in data:
+        with multiprocessing.Pool(processes=multiprocessing.cpu_count()) as pool:
+            p = pool.Process(target=worker, args=(partial_dict, d))
+            jobs.append(p)
+            p.start()
+
+    for proc in jobs:
+            proc.join()
+
+    r = partial_dict['r']
+    del partial_dict['r']
 
     if partial:
         return partial_dict
@@ -66,13 +81,12 @@ def compute_van_hove(trj, chunk_length, water=False,
 
     for key, val in partial_dict.items():
         elem1, elem2 = key
-        concentration1 = trj.atom_slice(trj.top.select('element {}'.format(elem1.symbol))).n_atoms / n_physical_atoms
-        concentration2 = trj.atom_slice(trj.top.select('element {}'.format(elem2.symbol))).n_atoms / n_physical_atoms
-        form_factor1 = get_form_factor(element_name=elem1.symbol, water=water)
-        form_factor2 = get_form_factor(element_name=elem2.symbol, water=water)
+        concentration1 = trj.atom_slice(trj.top.select(elem1)).n_atoms / n_physical_atoms
+        concentration2 = trj.atom_slice(trj.top.select(elem2)).n_atoms / n_physical_atoms
+        form_factor1 = get_form_factor(element_name=elem1.split()[1], water=water)
+        form_factor2 = get_form_factor(element_name=elem2.split()[1], water=water)
 
         coeff = form_factor1 * concentration1 * form_factor2 * concentration2
-
         if g_r_t is None:
             g_r_t = np.zeros_like(val)
         g_r_t += val * coeff
@@ -89,6 +103,13 @@ def compute_van_hove(trj, chunk_length, water=False,
     t = trj.time[:chunk_length]
 
     return r, t, g_r_t_final
+
+
+def worker(return_dict, data):
+    key = (data[2], data[3])
+    r, g_r_t_partial = compute_partial_van_hove(*data)
+    return_dict[key] = g_r_t_partial
+    return_dict['r'] = r
 
 
 def compute_partial_van_hove(trj, chunk_length=10, selection1=None, selection2=None,

--- a/scattering/van_hove.py
+++ b/scattering/van_hove.py
@@ -1,4 +1,5 @@
 import multiprocessing
+import sys
 import itertools as it
 
 import numpy as np
@@ -61,9 +62,14 @@ def compute_van_hove(trj, chunk_length, water=False,
     manager = multiprocessing.Manager()
     partial_dict = manager.dict()
     jobs = []
+    version_info = sys.version_info
     for d in data:
         with multiprocessing.Pool(processes=multiprocessing.cpu_count()) as pool:
-            p = pool.Process(target=worker, args=(partial_dict, d))
+            if version_info.major == 3 and version_info.minor <= 7:
+                p = pool.Process(target=worker, args=(partial_dict, d))
+            elif version_info.major == 3 and version_info.minor >= 8:
+                ctx = multiprocessing.get_context()
+                p = pool.Process(ctx, target=worker, args=(partial_dict, d))
             jobs.append(p)
             p.start()
 


### PR DESCRIPTION
Implements #19 

Actually some of the first decent-looking parallel Python code I've written

I considered a `parallel` boolean option but .... I'm not sure I see a downside to this being default? This uses what I believe are very stable functions, i.e. `multiprocessing.cpu_count()` won't brick your machine