### PR TITLE
Refactor form factor functions to handle solutions with water when `water=True`

### DIFF
--- a/scattering/tests/test_constants.py
+++ b/scattering/tests/test_constants.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+from scattering.utils.constants import get_form_factor
+from mdtraj.core.element import Element
+
+def test_form_factor():
+    li_form =  get_form_factor('li', water=False)
+
+    assert li_form == 3
+
+def test_water_form_factor():
+    o_form =  get_form_factor('O', water=True)
+    h_form =  get_form_factor('H', water=True)
+
+    assert np.isclose(o_form, 9.33333)
+    assert np.isclose(h_form, 1/3)
+
+def test_redirect_water_form_factor():
+    li_form =  get_form_factor('li', water=True)
+
+    assert li_form == 3

--- a/scattering/utils/constants.py
+++ b/scattering/utils/constants.py
@@ -4,27 +4,23 @@ from mdtraj.core.element import Element
 
 
 def get_form_factor(element_name=None, water=None):
+    if element_name is None:
+        raise ValueError('Need an element')
+
+    elem = Element.getBySymbol(element_name)
 
     if water:
-        return get_form_factor_water(element_name=element_name)
-
-    if element_name is not None:
-        elem = Element.getBySymbol(element_name)
+        if elem.atomic_number in [1, 8]:
+            return get_form_factor_water(element_name=element_name, elem=elem)
+        else: warnings.warn('`water` has been set to True but `element_name` does not equal `O` or `H`.')
 
     warnings.warn('Estimating atomic form factor as atomic number')
 
     form_factor = elem.atomic_number
     return form_factor if form_factor > 0 else 1
 
-def get_form_factor_water(element_name=None):
-    if element_name is not None:
-        elem = Element.getBySymbol(element_name)
-    else:
-        raise ValueError('Need an element')
-
-    if elem.atomic_number not in [1, 8]:
-        raise ValueError('')
-
+def get_form_factor_water(element_name=None, elem=None):
+    elem = Element.getBySymbol(element_name)
     if elem.atomic_number == 1:
         form_factor = float(1/3)
     elif elem.atomic_number == 8:


### PR DESCRIPTION
I'm running into an issue with solutions of water and ions.  I am wanting to use the specific form factors for water using the argument `water=True`.  However, an error occurs when trying to get a form factor for a non-water element when `water=True`.  To handle this, I moved the element conditionals in `get_water_form_factor` to `get_form_factor`.  If `water=True` AND the element has the atomic number of O or H, the `get_water_form_factor` will get called.  However, if the atomic number does not match that of O or H, then a warning gets raise and the atomic form factor is returned as the atomic number.  Tests have also been added to check this behavior.