### PR TITLE
Determine form factors from Cromer Mann tables

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,12 +41,14 @@ jobs:
       run: |
         conda info
         conda list
-
     - name: Install package
       shell: bash -l {0}
       run: |
         python setup.py develop --no-deps
-
+    - name: pip install additional packages
+      shell: bash -l {0}
+      run: |
+        pip install periodictable
     - name: Test with pytest
       if: always()
       shell: bash -l {0}

--- a/scattering/scattering.py
+++ b/scattering/scattering.py
@@ -10,12 +10,17 @@ from scattering.utils.utils import get_dt
 from scattering.utils.constants import get_form_factor
 
 
-#__all__ = ['structure_factor', 'compute_partial_van_hove', 'compute_van_hove']
+# __all__ = ['structure_factor', 'compute_partial_van_hove', 'compute_van_hove']
 
 
-
-def structure_factor(trj, Q_range=(0.5, 50), n_points=1000,
-        framewise_rdf=False, weighting_factor='fz', form="atomic"):
+def structure_factor(
+    trj,
+    Q_range=(0.5, 50),
+    n_points=1000,
+    framewise_rdf=False,
+    weighting_factor="fz",
+    form="atomic",
+):
     """Compute the structure factor through a fourier transform of
     the radial distribution function.
 
@@ -52,10 +57,13 @@ def structure_factor(trj, Q_range=(0.5, 50), n_points=1000,
         The structure factor of the trajectory
 
     """
-    if weighting_factor not in ['fz']:
-        raise ValueError('Invalid weighting_factor `{}` is given.'
-                         '  The only weighting_factor currently supported is `fz`.'.format(
-                             weighting_factor))
+    if weighting_factor not in ["fz"]:
+        raise ValueError(
+            "Invalid weighting_factor `{}` is given."
+            "  The only weighting_factor currently supported is `fz`.".format(
+                weighting_factor
+            )
+        )
 
     rho = np.mean(trj.n_atoms / trj.unitcell_volumes)
     L = np.min(trj.unitcell_lengths)
@@ -67,62 +75,66 @@ def structure_factor(trj, Q_range=(0.5, 50), n_points=1000,
     form_factors = dict()
     rdfs = dict()
 
-    Q = np.logspace(np.log10(Q_range[0]),
-                    np.log10(Q_range[1]),
-                    num=n_points)
+    Q = np.logspace(np.log10(Q_range[0]), np.log10(Q_range[1]), num=n_points)
     S = np.zeros(shape=(len(Q)))
 
     for elem in elements:
-        compositions[elem.symbol] = len(top.select('element {}'.format(elem.symbol)))/trj.n_atoms
-        form_factors[elem.symbol] = get_form_factor(elem.symbol, q=Q[0]/10, method=form)
+        compositions[elem.symbol] = (
+            len(top.select("element {}".format(elem.symbol))) / trj.n_atoms
+        )
+        form_factors[elem.symbol] = get_form_factor(
+            elem.symbol, q=Q[0] / 10, method=form
+        )
 
     for i, q in enumerate(Q):
         num = 0
         denom = 0
 
         for elem in elements:
-            denom += compositions[elem.symbol] * get_form_factor(elem.symbol,
-                    q=q/10, method=form)
+            denom += compositions[elem.symbol] * get_form_factor(
+                elem.symbol, q=q / 10, method=form
+            )
 
         for (elem1, elem2) in it.product(elements, repeat=2):
             e1 = elem1.symbol
             e2 = elem2.symbol
 
-            f_a = get_form_factor(e1, q=q/10, method=form)
-            f_b = get_form_factor(e2, q=q/10, method=form)
+            f_a = get_form_factor(e1, q=q / 10, method=form)
+            f_b = get_form_factor(e2, q=q / 10, method=form)
 
             x_a = compositions[e1]
             x_b = compositions[e2]
-            
+
             try:
-                g_r = rdfs['{0}{1}'.format(e1, e2)]
+                g_r = rdfs["{0}{1}".format(e1, e2)]
             except KeyError:
-                pairs = top.select_pairs(selection1='element {}'.format(e1),
-                                         selection2='element {}'.format(e2))
+                pairs = top.select_pairs(
+                    selection1="element {}".format(e1),
+                    selection2="element {}".format(e2),
+                )
                 if framewise_rdf:
-                    r, g_r = rdf_by_frame(trj,
-                                         pairs=pairs,
-                                         r_range=(0, L / 2),
-                                         bin_width=0.001)
+                    r, g_r = rdf_by_frame(
+                        trj, pairs=pairs, r_range=(0, L / 2), bin_width=0.001
+                    )
                 else:
-                    r, g_r = md.compute_rdf(trj,
-                                            pairs=pairs,
-                                            r_range=(0, L / 2),
-                                            bin_width=0.001)
-                rdfs['{0}{1}'.format(e1, e2)] = g_r
+                    r, g_r = md.compute_rdf(
+                        trj, pairs=pairs, r_range=(0, L / 2), bin_width=0.001
+                    )
+                rdfs["{0}{1}".format(e1, e2)] = g_r
             integral = simps(r ** 2 * (g_r - 1) * np.sin(q * r) / (q * r), r)
 
-            if weighting_factor == 'fz':
+            if weighting_factor == "fz":
                 pre_factor = 4 * np.pi * rho
-                partial_sq = (integral*pre_factor) + 1
-                num += (x_a*f_a*x_b*f_b) * (partial_sq)
-        S[i] = (num/(denom**2))
+                partial_sq = (integral * pre_factor) + 1
+                num += (x_a * f_a * x_b * f_b) * (partial_sq)
+        S[i] = num / (denom ** 2)
     return Q, S
+
 
 def compute_dynamic_rdf(trj):
     """Compute r_ij(t), the distance between atom j at time t and atom i and
     time 0. Note that this alone is likely useless, but is an intermediate
-    variable in the construction of a dynamic structure factor. 
+    variable in the construction of a dynamic structure factor.
     See 10.1103/PhysRevE.59.623.
 
     Parameters
@@ -144,12 +156,16 @@ def compute_dynamic_rdf(trj):
     for n_frame, frame in enumerate(trj):
         for atom_i in range(trj.n_atoms):
             for atom_j in range(trj.n_atoms):
-                r_ij[atom_i, atom_j, n_frame] = compute_distance(trj.xyz[n_frame, atom_j], trj.xyz[0, atom_i])
+                r_ij[atom_i, atom_j, n_frame] = compute_distance(
+                    trj.xyz[n_frame, atom_j], trj.xyz[0, atom_i]
+                )
 
     return r_ij
 
+
 def compute_distance(point1, point2):
-    return np.sqrt(np.sum((point1 -point2) ** 2))
+    return np.sqrt(np.sum((point1 - point2) ** 2))
+
 
 def compute_rdf_from_partial(trj, r_range=None):
     compositions = dict()
@@ -162,7 +178,9 @@ def compute_rdf_from_partial(trj, r_range=None):
 
     denom = 0
     for elem in elements:
-        compositions[elem.symbol] = len(top.select('element {}'.format(elem.symbol)))/trj.n_atoms
+        compositions[elem.symbol] = (
+            len(top.select("element {}".format(elem.symbol))) / trj.n_atoms
+        )
         form_factors[elem.symbol] = elem.atomic_number
         denom += compositions[elem.symbol] * form_factors[elem.symbol]
     for i, (elem1, elem2) in enumerate(it.product(elements, repeat=2)):
@@ -174,24 +192,21 @@ def compute_rdf_from_partial(trj, r_range=None):
 
         f_a = form_factors[e1]
         f_b = form_factors[e2]
-        
+
         try:
-            g_r = rdfs['{0}{1}'.format(e1, e2)]
+            g_r = rdfs["{0}{1}".format(e1, e2)]
         except KeyError:
-            pairs = top.select_pairs(selection1='element {}'.format(e1),
-                                     selection2='element {}'.format(e2))
+            pairs = top.select_pairs(
+                selection1="element {}".format(e1), selection2="element {}".format(e2)
+            )
             if r_range == None:
-                r, g_r = md.compute_rdf(trj,
-                                        pairs=pairs,
-                                        r_range=(0, L / 2))
+                r, g_r = md.compute_rdf(trj, pairs=pairs, r_range=(0, L / 2))
             else:
-                r, g_r = md.compute_rdf(trj,
-                                        pairs=pairs,
-                                        r_range=r_range)
-            rdfs['{0}{1}'.format(e1, e2)] = g_r
+                r, g_r = md.compute_rdf(trj, pairs=pairs, r_range=r_range)
+            rdfs["{0}{1}".format(e1, e2)] = g_r
         if i == 0:
-            total = g_r * (x_a*x_b*f_a*f_b) / denom**2
-        else: 
-            total += g_r * (x_a*x_b*f_a*f_b) / denom**2
+            total = g_r * (x_a * x_b * f_a * f_b) / denom ** 2
+        else:
+            total += g_r * (x_a * x_b * f_a * f_b) / denom ** 2
 
     return r, total

--- a/scattering/tests/test_scattering.py
+++ b/scattering/tests/test_scattering.py
@@ -6,26 +6,34 @@ import pytest
 from scattering.scattering import structure_factor
 from scattering.utils.io import get_fn
 
-@pytest.mark.parametrize('weighting_factor', ['fz'])
+
+@pytest.mark.parametrize("weighting_factor", ["fz"])
 def test_structure_factor(weighting_factor):
-    trj = md.load(
-        get_fn('spce.xtc'),
-        top=get_fn('spce.gro')
-    )[:100]
+    trj = md.load(get_fn("spce.xtc"), top=get_fn("spce.gro"))[:100]
 
-    Q, S = structure_factor(trj,
-                            Q_range=(0.5, 200),
-                            framewise_rdf=False,
-                            weighting_factor=weighting_factor)
+    Q, S = structure_factor(
+        trj, Q_range=(0.5, 200), framewise_rdf=False, weighting_factor=weighting_factor
+    )
 
-def test_invalid_sq_weigting_factor():
-    trj = md.load(
-        get_fn('spce.xtc'),
-        top=get_fn('spce.gro')
-    )[:100]
+
+@pytest.mark.parametrize("form", ["atomic", "cromer-mann"])
+def test_sq_form(form):
+    trj = md.load(get_fn("spce.xtc"), top=get_fn("spce.gro"))[:100]
+
+    Q, S = structure_factor(trj, Q_range=(0.5, 200), framewise_rdf=False, form=form)
+
+
+def test_invalid_form_style():
+    trj = md.load(get_fn("spce.xtc"), top=get_fn("spce.gro"))[:100]
 
     with pytest.raises(ValueError):
-        Q, S = structure_factor(trj,
-                                Q_range=(0.5, 200),
-                                framewise_rdf=False,
-                                weighting_factor='invalid')
+        structure_factor(trj, Q_range=(0.5, 200), framewise_rdf=False, form="random")
+
+
+def test_invalid_sq_weigting_factor():
+    trj = md.load(get_fn("spce.xtc"), top=get_fn("spce.gro"))[:100]
+
+    with pytest.raises(ValueError):
+        Q, S = structure_factor(
+            trj, Q_range=(0.5, 200), framewise_rdf=False, weighting_factor="invalid"
+        )

--- a/scattering/utils/constants.py
+++ b/scattering/utils/constants.py
@@ -21,6 +21,8 @@ def get_form_factor(element_name=None, q=None, method="atomic", water=None):
         form_factor = elem.atomic_number
     elif method == "cromer-mann":
         form_factor = cromermann.fxrayatq(elem.symbol, q)
+    else:
+        raise ValueError(f"Invalid method {method}.  Use `atomic` or `cromer-mann`.")
     return form_factor if form_factor > 0 else 1
 
 def get_form_factor_water(element_name=None):

--- a/scattering/utils/constants.py
+++ b/scattering/utils/constants.py
@@ -1,9 +1,13 @@
 import warnings
 
 from mdtraj.core.element import Element
+from periodictable import cromermann
 
 
-def get_form_factor(element_name=None, water=None):
+def get_form_factor(element_name=None, q=None, method="atomic", water=None):
+    """Get form factor for elements"""
+    if method == "cromer-mann" and q is None:
+        raise ValueError("q must be a non-null value when method='cromer-mann'")
 
     if water:
         return get_form_factor_water(element_name=element_name)
@@ -12,8 +16,11 @@ def get_form_factor(element_name=None, water=None):
         elem = Element.getBySymbol(element_name)
 
     warnings.warn('Estimating atomic form factor as atomic number')
-
-    form_factor = elem.atomic_number
+    
+    if method == "atomic":
+        form_factor = elem.atomic_number
+    elif method == "cromer-mann":
+        form_factor = cromermann.fxrayatq(elem.symbol, q)
     return form_factor if form_factor > 0 else 1
 
 def get_form_factor_water(element_name=None):


### PR DESCRIPTION
This PR addresses #1 to evaluate the form factors.  Currently, I added a dependency for the package `periodic table` (https://periodictable.readthedocs.io/en/latest/api/cromermann.html) to get the form factors from cromer-mann tables.

Attached is the current agreement with TRAVIS.  The agreement is better than before when using the atomic number, but still isn't perfect.  This is due to slight differences in cromer-mann coefficients between `periodic table` and TRAVIS.  I may have to manually input these coefficients to reach complete agreement with TRAVIS.