### PR TITLE
Check self correlations for non-monatomic pairs

### DIFF
--- a/scattering/tests/test_van_hove.py
+++ b/scattering/tests/test_van_hove.py
@@ -1,15 +1,14 @@
 import numpy as np
+import pytest
 import matplotlib.pyplot as plt
 import mdtraj as md
 
-from scattering.van_hove import compute_van_hove
+from scattering.van_hove import compute_van_hove, compute_partial_van_hove
 from scattering.utils.io import get_fn
 
+
 def test_van_hove():
-    trj = md.load(
-        get_fn('spce.xtc'),
-        top=get_fn('spce.gro')
-    )
+    trj = md.load(get_fn("spce.xtc"), top=get_fn("spce.gro"))
 
     chunk_length = 2
 
@@ -24,26 +23,22 @@ def test_van_hove():
 
     fig, ax = plt.subplots()
     for i in range(len(t)):
-        ax.plot(r, g_r_t[i], '.-', label=t[i])
+        ax.plot(r, g_r_t[i], ".-", label=t[i])
     ax.set_ylim((0, 3))
     ax.legend()
-    fig.savefig('vhf.pdf')
+    fig.savefig("vhf.pdf")
+
 
 def test_serial_van_hove():
-    trj = md.load(
-        get_fn('spce.xtc'),
-        top=get_fn('spce.gro')
-    )
+    trj = md.load(get_fn("spce.xtc"), top=get_fn("spce.gro"))
 
     chunk_length = 2
 
     r, t, g_r_t = compute_van_hove(trj, chunk_length=chunk_length, parallel=False)
 
+
 def test_van_hove_equal():
-    trj = md.load(
-        get_fn('spce.xtc'),
-        top=get_fn('spce.gro')
-    )
+    trj = md.load(get_fn("spce.xtc"), top=get_fn("spce.gro"))
 
     chunk_length = 2
 
@@ -53,3 +48,18 @@ def test_van_hove_equal():
     assert np.allclose(r_p, r_s)
     assert np.allclose(t_p, t_s)
     assert np.allclose(g_r_t_p, g_r_t_s)
+
+
+def test_self_warning():
+    trj = md.load(get_fn("spce.xtc"), top=get_fn("spce.gro"))
+
+    chunk_length = 2
+
+    with pytest.warns(UserWarning):
+        compute_partial_van_hove(
+            trj,
+            chunk_length=chunk_length,
+            selection1="name O",
+            selection2="name H",
+            self_correlation=True,
+        )

--- a/scattering/tests/test_van_hove.py
+++ b/scattering/tests/test_van_hove.py
@@ -50,7 +50,7 @@ def test_van_hove_equal():
     assert np.allclose(g_r_t_p, g_r_t_s)
 
 
-def test_self_warning():
+def test_self_partial_warning():
     trj = md.load(get_fn("spce.xtc"), top=get_fn("spce.gro"))
 
     chunk_length = 2
@@ -61,5 +61,18 @@ def test_self_warning():
             chunk_length=chunk_length,
             selection1="name O",
             selection2="name H",
+            self_correlation=True,
+        )
+
+
+def test_self_warning():
+    trj = md.load(get_fn("spce.xtc"), top=get_fn("spce.gro"))
+
+    chunk_length = 2
+
+    with pytest.warns(UserWarning):
+        compute_van_hove(
+            trj,
+            chunk_length=chunk_length,
             self_correlation=True,
         )

--- a/scattering/tests/test_van_hove.py
+++ b/scattering/tests/test_van_hove.py
@@ -55,7 +55,7 @@ def test_self_partial_warning():
 
     chunk_length = 2
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(UserWarning, match=r"Partial VHF"):
         compute_partial_van_hove(
             trj,
             chunk_length=chunk_length,
@@ -65,14 +65,16 @@ def test_self_partial_warning():
         )
 
 
-def test_self_warning():
+@pytest.mark.parametrize("parallel", [True, False])
+def test_self_warning(parallel):
     trj = md.load(get_fn("spce.xtc"), top=get_fn("spce.gro"))
 
     chunk_length = 2
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(UserWarning, match=r"Total VHF"):
         compute_van_hove(
             trj,
             chunk_length=chunk_length,
             self_correlation=True,
+            parallel=parallel,
         )

--- a/scattering/van_hove.py
+++ b/scattering/van_hove.py
@@ -62,6 +62,16 @@ def compute_van_hove(
     if parallel:
         data = []
         for elem1, elem2 in it.combinations_with_replacement(unique_elements[::-1], 2):
+            # Add a bool to check if self-correlations should be analyzed
+            self_bool = self_correlation
+            if elem1 != elem2:
+                self_bool = False
+                warnings.warn(
+                    "Total VHF calculation: No self-correlations for {} and {}, setting `self_correlation` to `False`.".format(
+                        elem1, elem2
+                    )
+                )
+
             data.append(
                 [
                     trj,
@@ -71,7 +81,7 @@ def compute_van_hove(
                     r_range,
                     bin_width,
                     n_bins,
-                    self_correlation,
+                    self_bool,
                     periodic,
                     opt,
                 ]
@@ -101,6 +111,16 @@ def compute_van_hove(
         partial_dict = dict()
 
         for elem1, elem2 in it.combinations_with_replacement(unique_elements[::-1], 2):
+            # Add a bool to check if self-correlations should be analyzed
+            self_bool = self_correlation
+            if elem1 != elem2:
+                self_bool = False
+                warnings.warn(
+                    "Total VHF calculation: No self-correlations for {} and {}, setting `self_correlation` to `False`.".format(
+                        elem1, elem2
+                    )
+                )
+
             print("doing {0} and {1} ...".format(elem1, elem2))
             r, g_r_t_partial = compute_partial_van_hove(
                 trj=trj,
@@ -110,7 +130,7 @@ def compute_van_hove(
                 r_range=r_range,
                 bin_width=bin_width,
                 n_bins=n_bins,
-                self_correlation=self_correlation,
+                self_correlation=self_bool,
                 periodic=periodic,
                 opt=opt,
             )
@@ -217,7 +237,7 @@ def compute_partial_van_hove(
     # If not, do not calculate self correlations
     if selection1 != selection2 and self_correlation == True:
         warnings.warn(
-            "No self-correlations for {} and {}, setting `self_correlation` to `False`.".format(
+            "Partial VHF calculation: No self-correlations for {} and {}, setting `self_correlation` to `False`.".format(
                 selection1, selection2
             )
         )

--- a/scattering/van_hove.py
+++ b/scattering/van_hove.py
@@ -1,6 +1,7 @@
 import multiprocessing
 import sys
 import itertools as it
+import warnings
 
 import numpy as np
 import mdtraj as md
@@ -10,9 +11,19 @@ from scattering.utils.utils import get_dt
 from scattering.utils.constants import get_form_factor
 
 
-def compute_van_hove(trj, chunk_length, parallel=False, water=False,
-                     r_range=(0, 1.0), bin_width=0.005, n_bins=None,
-                     self_correlation=True, periodic=True, opt=True, partial=False):
+def compute_van_hove(
+    trj,
+    chunk_length,
+    parallel=False,
+    water=False,
+    r_range=(0, 1.0),
+    bin_width=0.005,
+    n_bins=None,
+    self_correlation=True,
+    periodic=True,
+    opt=True,
+    partial=False,
+):
     """Compute the partial van Hove function of a trajectory
 
     Parameters
@@ -44,23 +55,27 @@ def compute_van_hove(trj, chunk_length, parallel=False, water=False,
     """
 
     n_physical_atoms = len([a for a in trj.top.atoms if a.element.mass > 0])
-    unique_elements = list(set([a.element for a in trj.top.atoms if a.element.mass > 0]))
+    unique_elements = list(
+        set([a.element for a in trj.top.atoms if a.element.mass > 0])
+    )
 
     if parallel:
         data = []
         for elem1, elem2 in it.combinations_with_replacement(unique_elements[::-1], 2):
-            data.append([
-                trj,
-                chunk_length,
-                'element {}'.format(elem1.symbol),
-                'element {}'.format(elem2.symbol),
-                r_range,
-                bin_width,
-                n_bins,
-                self_correlation,
-                periodic,
-                opt,
-            ])
+            data.append(
+                [
+                    trj,
+                    chunk_length,
+                    "element {}".format(elem1.symbol),
+                    "element {}".format(elem2.symbol),
+                    r_range,
+                    bin_width,
+                    n_bins,
+                    self_correlation,
+                    periodic,
+                    opt,
+                ]
+            )
 
         manager = multiprocessing.Manager()
         partial_dict = manager.dict()
@@ -77,27 +92,31 @@ def compute_van_hove(trj, chunk_length, parallel=False, water=False,
                 p.start()
 
         for proc in jobs:
-                proc.join()
+            proc.join()
 
-        r = partial_dict['r']
-        del partial_dict['r']
+        r = partial_dict["r"]
+        del partial_dict["r"]
 
     else:
         partial_dict = dict()
 
         for elem1, elem2 in it.combinations_with_replacement(unique_elements[::-1], 2):
-            print('doing {0} and {1} ...'.format(elem1, elem2))
-            r, g_r_t_partial = compute_partial_van_hove(trj=trj,
-                                                        chunk_length=chunk_length,
-                                                        selection1='element {}'.format(elem1.symbol),
-                                                        selection2='element {}'.format(elem2.symbol),
-                                                        r_range=r_range,
-                                                        bin_width=bin_width,
-                                                        n_bins=n_bins,
-                                                        self_correlation=self_correlation,
-                                                        periodic=periodic,
-                                                        opt=opt)
-            partial_dict[('element {}'.format(elem1.symbol), 'element {}'.format(elem2.symbol))] = g_r_t_partial
+            print("doing {0} and {1} ...".format(elem1, elem2))
+            r, g_r_t_partial = compute_partial_van_hove(
+                trj=trj,
+                chunk_length=chunk_length,
+                selection1="element {}".format(elem1.symbol),
+                selection2="element {}".format(elem2.symbol),
+                r_range=r_range,
+                bin_width=bin_width,
+                n_bins=n_bins,
+                self_correlation=self_correlation,
+                periodic=periodic,
+                opt=opt,
+            )
+            partial_dict[
+                ("element {}".format(elem1.symbol), "element {}".format(elem2.symbol))
+            ] = g_r_t_partial
 
     if partial:
         return partial_dict
@@ -107,8 +126,12 @@ def compute_van_hove(trj, chunk_length, parallel=False, water=False,
 
     for key, val in partial_dict.items():
         elem1, elem2 = key
-        concentration1 = trj.atom_slice(trj.top.select(elem1)).n_atoms / n_physical_atoms
-        concentration2 = trj.atom_slice(trj.top.select(elem2)).n_atoms / n_physical_atoms
+        concentration1 = (
+            trj.atom_slice(trj.top.select(elem1)).n_atoms / n_physical_atoms
+        )
+        concentration2 = (
+            trj.atom_slice(trj.top.select(elem2)).n_atoms / n_physical_atoms
+        )
         form_factor1 = get_form_factor(element_name=elem1.split()[1], water=water)
         form_factor2 = get_form_factor(element_name=elem2.split()[1], water=water)
 
@@ -135,12 +158,21 @@ def worker(return_dict, data):
     key = (data[2], data[3])
     r, g_r_t_partial = compute_partial_van_hove(*data)
     return_dict[key] = g_r_t_partial
-    return_dict['r'] = r
+    return_dict["r"] = r
 
 
-def compute_partial_van_hove(trj, chunk_length=10, selection1=None, selection2=None,
-                             r_range=(0, 1.0), bin_width=0.005, n_bins=200,
-                             self_correlation=True, periodic=True, opt=True):
+def compute_partial_van_hove(
+    trj,
+    chunk_length=10,
+    selection1=None,
+    selection2=None,
+    r_range=(0, 1.0),
+    bin_width=0.005,
+    n_bins=200,
+    self_correlation=True,
+    periodic=True,
+    opt=True,
+):
     """Compute the partial van Hove function of a trajectory
 
     Parameters
@@ -170,7 +202,6 @@ def compute_partial_van_hove(trj, chunk_length=10, selection1=None, selection2=N
     g_r_t : numpy.ndarray
         Van Hove function at each time and position
     """
-
     unique_elements = (
         set([a.element for a in trj.atom_slice(trj.top.select(selection1)).top.atoms]),
         set([a.element for a in trj.atom_slice(trj.top.select(selection2)).top.atoms]),
@@ -178,9 +209,19 @@ def compute_partial_van_hove(trj, chunk_length=10, selection1=None, selection2=N
 
     if any([len(val) > 1 for val in unique_elements]):
         raise UserWarning(
-            'Multiple elements found in a selection(s). Results may not be '
-            'direcitly comprable to scattering experiments.'
+            "Multiple elements found in a selection(s). Results may not be "
+            "direcitly comprable to scattering experiments."
         )
+
+    # Check if pair is monatomic
+    # If not, do not calculate self correlations
+    if selection1 != selection2 and self_correlation == True:
+        warnings.warn(
+            "No self-correlations for {} and {}, setting `self_correlation` to `False`.".format(
+                selection1, selection2
+            )
+        )
+        self_correlation = False
 
     # Don't need to store it, but this serves to check that dt is constant
     dt = get_dt(trj)
@@ -195,7 +236,7 @@ def compute_partial_van_hove(trj, chunk_length=10, selection1=None, selection2=N
     for i in pbar(range(n_chunks)):
         times = list()
         for j in range(chunk_length):
-            times.append([chunk_length*i, chunk_length*i+j])
+            times.append([chunk_length * i, chunk_length * i + j])
         r, g_r_t_frame = md.compute_rdf_t(
             traj=trj,
             pairs=pairs,


### PR DESCRIPTION
For non-monatomic pairs (oxygen-hydrogen), we shouldn't calculate any self-interactions even if `self_correlation=True` .  This PR adds a check to `compute_partial_van_hove` which sets `self_correlation` to False if `selection1 != selection2`.  User is warned if this happens.

Test case has also been added to check that warning is properly raised.