### PR TITLE
Change selection arguments for run_partial function

### DIFF
--- a/scattering/tests/test_run.py
+++ b/scattering/tests/test_run.py
@@ -5,17 +5,17 @@ import pytest
 from scattering.utils.io import get_fn
 from scattering.utils.run import run_total_vhf, run_partial_vhf
 
+
 @pytest.mark.parametrize("step", [1, 2])
 def test_run_total_vhf(step):
-    trj = md.load(
-        get_fn('spce.xtc'),
-        top=get_fn('spce.gro')
-    )
+    trj = md.load(get_fn("spce.xtc"), top=get_fn("spce.gro"))
 
     chunk_length = 4
-    n_chunks=5
+    n_chunks = 5
 
-    r, t, g_r_t = run_total_vhf(trj, step=step, chunk_length=chunk_length, n_chunks=n_chunks)
+    r, t, g_r_t = run_total_vhf(
+        trj, step=step, chunk_length=chunk_length, n_chunks=n_chunks
+    )
 
     assert len(t) == chunk_length / step
     assert len(r) == 200
@@ -24,18 +24,23 @@ def test_run_total_vhf(step):
     # Check normalization to ~1
     assert 0.95 < np.mean(g_r_t[:, -10:]) < 1.05
 
+
 @pytest.mark.parametrize("step", [1, 2])
 def test_run_partial_vhf(step):
-    trj = md.load(
-        get_fn('spce.xtc'),
-        top=get_fn('spce.gro')
-    )
+    trj = md.load(get_fn("spce.xtc"), top=get_fn("spce.gro"))
 
     chunk_length = 4
-    n_chunks=5
+    n_chunks = 5
 
     combo = ["O", "O"]
-    r, t, g_r_t = run_partial_vhf(trj, step=step, selection1=combo[0], selection2=combo[1], chunk_length=chunk_length, n_chunks=n_chunks)
+    r, t, g_r_t = run_partial_vhf(
+        trj,
+        step=step,
+        selection1=f"element {combo[0]}",
+        selection2=f"element {combo[1]}",
+        chunk_length=chunk_length,
+        n_chunks=n_chunks,
+    )
 
     assert len(t) == chunk_length / step
     assert len(r) == 200

--- a/scattering/utils/run.py
+++ b/scattering/utils/run.py
@@ -126,8 +126,8 @@ def run_partial_vhf(trj, chunk_length, selection1, selection2, n_chunks, water=T
         print(f"Analyzing frames {start} to {end}...")
         r, g_r_t = compute_partial_van_hove(trj=chunk,
                                        chunk_length=frames_in_chunk,
-                                       selection1='element {}'.format(selection1),
-                                       selection2='element {}'.format(selection2),
+                                       selection1=selection1,
+                                       selection2=selection2,
                                        r_range=r_range,
                                        bin_width=bin_width,
                                        n_bins=n_bins,


### PR DESCRIPTION
Change `selection1` and `selection2` arguments in `run_partial_vhf` to allow more general atom selection language from MDTraj.  Test has been updated.