### PR TITLE
Changed vhf_from_pvhf dictionary inputs

### DIFF
--- a/scattering/tests/test_van_hove.py
+++ b/scattering/tests/test_van_hove.py
@@ -163,6 +163,25 @@ def test_pvhf_error_2_atoms_per_pair():
         vhf_from_pvhf(trj, partial_dict, element_dict)
 
 
+def test_pvhf_invalid_atom():
+    trj = md.load(get_fn("spce.xtc"), top=get_fn("spce.gro"))
+    atom_names = list(set([atom.name for atom in trj.topology.atoms]))
+    element_dict = {}
+    for atom in trj.topology.atoms:
+        element_dict[atom.name] = atom.element.symbol
+    partial_dict = {}
+    x = compute_partial_van_hove(
+        trj,
+        chunk_length=20,
+        selection1="name O",
+        selection2="name O",
+    )
+    partial_dict[("O", 2)] = x[1]
+
+    with pytest.raises(ValueError, match="Atom name not valid, must be type."):
+        vhf_from_pvhf(trj, partial_dict, element_dict)
+
+
 def test_pvhf_error_atoms_in_trj():
     trj = md.load(get_fn("spce.xtc"), top=get_fn("spce.gro"))
     atom_names = list(set([atom.name for atom in trj.topology.atoms]))

--- a/scattering/tests/test_van_hove.py
+++ b/scattering/tests/test_van_hove.py
@@ -91,42 +91,52 @@ def test_self_warning(parallel):
 
 def test_vhf_from_pvhf():
     trj = md.load(get_fn("spce.xtc"), top=get_fn("spce.gro"))
-    unique_atoms = get_unique_atoms(trj)
-    tuples_combination = combinations_with_replacement(unique_atoms, 2)
+
+    #obtaining element dictionaries with element name values and corresponding atom name keys
+    element_dict = {}
+    for atom in trj.topology.atoms:
+        element_dict[atom.name] = atom.element.symbol
+
 
     # obtaining g_r_t from total func
     chunk_length = 20
     r, t, g_r_t = compute_van_hove(trj, chunk_length=chunk_length)
     partial_dict = compute_van_hove(trj, chunk_length=chunk_length, partial=True)
-    # obtating dict of np.array of pvhf
+
+
+    # obtating pvhf dict of np.array as values and atom name as keys
     partial_dict = {}
+    atom_names = set([atom.name for atom in trj.topology.atoms])
+    tuples_combination = combinations_with_replacement(atom_names, 2)
 
     for pairs in tuples_combination:
         pair1 = pairs[0]
         pair2 = pairs[1]
         # Set in alphabetical order
-        if pairs[0].name > pairs[1].name:
+        if pairs[0] > pairs[1]:
             pair2 = pairs[0]
             pair1 = pairs[1]
 
         x = compute_partial_van_hove(
             trj,
             chunk_length=chunk_length,
-            selection1=f"name {pair1.name}",
-            selection2=f"name {pair2.name}",
+            selection1=f"name {pair1}",
+            selection2=f"name {pair2}",
         )
         partial_dict[pairs] = x[1]
 
     # obtaining total_grt from partial
-    total_g_r_t = vhf_from_pvhf(trj, partial_dict)
+    total_g_r_t = vhf_from_pvhf(trj, partial_dict, element_dict)
 
     assert np.allclose(g_r_t, total_g_r_t)
 
 
 def test_pvhf_error_2_atoms_per_pair():
     trj = md.load(get_fn("spce.xtc"), top=get_fn("spce.gro"))
-    unique_atoms = get_unique_atoms(trj)
-
+    atom_names = list(set([atom.name for atom in trj.topology.atoms]))
+    element_dict = {}
+    for atom in trj.topology.atoms:
+        element_dict[atom.name] = atom.element.symbol
     partial_dict = {}
     x = compute_partial_van_hove(
         trj,
@@ -134,20 +144,23 @@ def test_pvhf_error_2_atoms_per_pair():
         selection1="name O",
         selection2="name O",
     )
-    partial_dict[(unique_atoms[0], unique_atoms[1], unique_atoms[1])] = x[1]
+    partial_dict[(atom_names[0], atom_names[1], atom_names[1])] = x[1]
 
     with pytest.raises(
         ValueError, match="Dictionary key not valid. Must only have 2 atoms per pair"
     ):
-        vhf_from_pvhf(trj, partial_dict)
+        vhf_from_pvhf(trj, partial_dict, element_dict)
 
 
 def test_pvhf_error_atoms_in_trj():
     trj = md.load(get_fn("spce.xtc"), top=get_fn("spce.gro"))
-    unique_atoms = get_unique_atoms(trj)
+    atom_names = list(set([atom.name for atom in trj.topology.atoms]))
     atom = md.core.topology.Atom(
         name="Na", element=md.core.element.sodium, index=0, residue=1
     )
+    element_dict = {}
+    for atom in trj.topology.atoms:
+        element_dict[atom.name] = atom.element.symbol
 
     partial_dict = {}
     x = compute_partial_van_hove(
@@ -156,37 +169,22 @@ def test_pvhf_error_atoms_in_trj():
         selection1="name O",
         selection2="name O",
     )
-    partial_dict[(atom, unique_atoms[0])] = x[1]
+    partial_dict[(atom, atom_names[0])] = x[1]
 
     with pytest.raises(
-        ValueError, match="Dictionary key not valid, `Atom`"
+        ValueError, match= f"Dictionary key not valid, `Atom` {atom} not in MDTraj trajectory."
     ):
-        vhf_from_pvhf(trj, partial_dict)
-
-
-def test_pvhf_error_is_atom_type():
-    trj = md.load(get_fn("spce.xtc"), top=get_fn("spce.gro"))
-    unique_atoms = get_unique_atoms(trj)
-
-    partial_dict = {}
-    x = compute_partial_van_hove(
-        trj,
-        chunk_length=20,
-        selection1="name O",
-        selection2="name O",
-    )
-    partial_dict[("H", "O")] = x[1]
-
-    with pytest.raises(
-        ValueError, match="Dictionary key not valid. Must be type"
-    ):
-        vhf_from_pvhf(trj, partial_dict)
+        vhf_from_pvhf(trj, partial_dict, element_dict)
 
 
 def test_pvhf_error_is_tuple():
     trj = md.load(get_fn("spce.xtc"), top=get_fn("spce.gro"))
     unique_atoms = get_unique_atoms(trj)
-    key = frozenset({unique_atoms[0], unique_atoms[1]})
+    element_dict = {}
+    for atom in trj.topology.atoms:
+        element_dict[atom.name] = atom.element.symbol
+
+    key = frozenset(('H', 'O'))
     partial_dict = {}
     x = compute_partial_van_hove(
         trj,
@@ -197,4 +195,4 @@ def test_pvhf_error_is_tuple():
     partial_dict[key] = x[1]
 
     with pytest.raises(ValueError, match="Dictionary key not valid. Must be a tuple"):
-        vhf_from_pvhf(trj, partial_dict)
+        vhf_from_pvhf(trj, partial_dict, element_dict)

--- a/scattering/tests/test_van_hove.py
+++ b/scattering/tests/test_van_hove.py
@@ -185,7 +185,7 @@ def test_pvhf_invalid_atom():
 def test_pvhf_error_atoms_in_trj():
     trj = md.load(get_fn("spce.xtc"), top=get_fn("spce.gro"))
     atom_names = list(set([atom.name for atom in trj.topology.atoms]))
-    atom = md.core.topology.Atom(
+    wrong_atom = md.core.topology.Atom(
         name="Na", element=md.core.element.sodium, index=0, residue=1
     )
     element_dict = {}
@@ -199,11 +199,11 @@ def test_pvhf_error_atoms_in_trj():
         selection1="name O",
         selection2="name O",
     )
-    partial_dict[(atom, atom_names[0])] = x[1]
+    partial_dict[(wrong_atom.name, atom_names[0])] = x[1]
 
     with pytest.raises(
         ValueError,
-        match=f"Dictionary key not valid, `Atom` {atom} not in MDTraj trajectory.",
+        match=f"Dictionary key not valid, `Atom` {wrong_atom.name} not in MDTraj trajectory.",
     ):
         vhf_from_pvhf(trj, partial_dict, element_dict)
 

--- a/scattering/van_hove.py
+++ b/scattering/van_hove.py
@@ -307,13 +307,13 @@ def vhf_from_pvhf(trj, partial_dict, element_dict, water=False):
     Parameters
     ----------
     trj : mdtrj.Trajectory
-        trajectory on which partial vhf were calculated form
-    partial_dict : dict
-        dictionary containing partial vhf as a np.array.
-        Key is a tuple of len 2 with 2 atom name
+        Trajectory in which partial VHFs were calculated from
+    partial_dict
+        Dictionary containing the partial VHFs as a np.array.
+        Key is a tuple like (atom1.name, atom2.name) of len=2.
     element_dict: dict
-        dictionary containing element names corresponding to the atom name.
-        Key is an atom name 
+        Dictionary containing element names corresponding to the atom name.
+        Key is an atom name.
 
     Return
     -------
@@ -326,6 +326,14 @@ def vhf_from_pvhf(trj, partial_dict, element_dict, water=False):
     norm_coeff = 0
     dict_shape = list(partial_dict.values())[0][0].shape
     total_grt = np.zeros(dict_shape)
+
+    # Validate element_dict
+    ele_key_type = list(set(type(k) for k in element_dict.keys()))
+    ele_value_type = list(set(type(k) for k in element_dict.values()))
+    if ele_key_type[0] != str or len(ele_key_type) > 1:
+        raise ValueError(f"Dictionary keys not valid, must be type(str).")
+    if ele_value_type[0] != str or len(ele_value_type) > 1:
+        raise ValueError(f"Dictionary values not valid, must be type(str).")
 
     for atom_pair in partial_dict.keys():
         # checks if key is a tuple

--- a/scattering/van_hove.py
+++ b/scattering/van_hove.py
@@ -288,7 +288,7 @@ def compute_partial_van_hove(
     return r, g_r_t
 
 
-def vhf_from_pvhf(trj, partial_dict, water=False):
+def vhf_from_pvhf(trj, partial_dict, element_dict, water=False):
     """
     Compute the total Van Hove function from partial Van Hove functions
 
@@ -299,7 +299,10 @@ def vhf_from_pvhf(trj, partial_dict, water=False):
         trajectory on which partial vhf were calculated form
     partial_dict : dict
         dictionary containing partial vhf as a np.array.
-        Key is a tuple of len 2 with 2 atom types
+        Key is a tuple of len 2 with 2 atom name
+    element_dict: dict
+        dictionary containing element names corresponding to the atom name.
+        Key is an atom name 
 
     Return
     -------
@@ -307,7 +310,7 @@ def vhf_from_pvhf(trj, partial_dict, water=False):
         Total Van Hove Function generated from addition of partial Van Hove Functions
     """
     unique_atoms = get_unique_atoms(trj)
-    all_atoms = [atom for atom in trj.topology.atoms]
+    atom_names = set([atom.name for atom in trj.topology.atoms])
 
     norm_coeff = 0
     dict_shape = list(partial_dict.values())[0][0].shape
@@ -318,13 +321,7 @@ def vhf_from_pvhf(trj, partial_dict, water=False):
         if isinstance(atom_pair, tuple) == False:
             raise ValueError("Dictionary key not valid. Must be a tuple.")
         for atom in atom_pair:
-            # checks if the atoms in tuple pair are atom types
-            if type(atom) != type(unique_atoms[0]):
-                raise ValueError(
-                    "Dictionary key not valid. Must be type `MDTraj.Atom`."
-                )
-            # checks if atoms are in the trajectory
-            if atom not in all_atoms:
+            if atom not in atom_names:
                 raise ValueError(
                     f"Dictionary key not valid, `Atom` {atom} not in MDTraj trajectory."
                 )
@@ -338,11 +335,11 @@ def vhf_from_pvhf(trj, partial_dict, water=False):
         atom1 = atom_pair[0]
         atom2 = atom_pair[1]
         coeff = (
-            get_form_factor(element_name=f"{atom1.element.symbol}", water=False)
-            * get_form_factor(element_name=f"{atom2.element.symbol}", water=False)
-            * len(trj.topology.select(f"name {atom1.name}"))
+            get_form_factor(element_name=f"{element_dict[atom1]}", water=False)
+            * get_form_factor(element_name=f"{element_dict[atom2]}", water=False)
+            * len(trj.topology.select(f"name {atom1}"))
             / (trj.n_atoms)
-            * len(trj.topology.select(f"name {atom2.name}"))
+            * len(trj.topology.select(f"name {atom2}"))
             / (trj.n_atoms)
         )
 

--- a/scattering/van_hove.py
+++ b/scattering/van_hove.py
@@ -340,6 +340,8 @@ def vhf_from_pvhf(trj, partial_dict, element_dict, water=False):
         if isinstance(atom_pair, tuple) == False:
             raise ValueError("Dictionary key not valid. Must be a tuple.")
         for atom in atom_pair:
+            if not isinstance(atom, str):
+                raise ValueError("Atom name not valid, must be type(str).")
             if atom not in atom_names:
                 raise ValueError(
                     f"Dictionary key not valid, `Atom` {atom} not in MDTraj trajectory."


### PR DESCRIPTION
Dictionary keys for pvhf passed in for `vhf_from_pvhf` is previously an `MDTraj.Atom` object. For clarity, users must now pass two dictionaries: 1. dictionary with values of pvhf as np.array and atom names as keys & 2. dictionary with values of element symbol and atom names as keys